### PR TITLE
Specify templates and static folder to let the data files installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,8 @@ setup(
     description='Google Charts API support for Flask',
     long_description=__doc__,
     packages=['flask_googlecharts'],
+    package_data={
+        'flask_googlecharts': ['templates/*', 'static/*'], },
     py_modules=['flask_googlecharts'],
     zip_safe=False,
     platforms='any',


### PR DESCRIPTION
Fix jinja2.exceptions.TemplateNotFound: init.js
Files in templates and static folder are not installed.
Fix by adding them to package_data.